### PR TITLE
Phase 8: Battle UI, fog-of-war, action panel, and event log

### DIFF
--- a/src/client/scenes/Battle.tscn
+++ b/src/client/scenes/Battle.tscn
@@ -1,38 +1,99 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://src/client/scripts/Battle.gd" id="1_battle"]
+[ext_resource type="PackedScene" path="res://src/client/scenes/BattlefieldGridUI.tscn" id="2_gridui"]
 
-[node name="root" type="Control" unique_id=1818665377]
+[node name="root" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1_battle")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -100.0
-offset_top = -60.0
-offset_right = 100.0
-offset_bottom = 60.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
 
-[node name="TitleLabel" type="Label" parent="VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
-text = "Battle"
+theme_override_constants/separation = 6
 
-[node name="PlaceholderLabel" type="Label" parent="VBoxContainer"]
+[node name="StatusBar" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
-text = "Battle — coming soon"
+theme_override_constants/separation = 8
 
-[node name="EndBattleButton" type="Button" parent="VBoxContainer"]
+[node name="TurnLabel" type="Label" parent="MarginContainer/VBoxContainer/StatusBar"]
+unique_name_in_owner = true
 layout_mode = 2
-text = "End Battle"
+text = "Turn: 1"
 
-[connection signal="pressed" from="VBoxContainer/EndBattleButton" to="." method="_on_end_battle_button_pressed"]
+[node name="StatusLabel" type="Label" parent="MarginContainer/VBoxContainer/StatusBar"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Waiting…"
+
+[node name="EndTurnButton" type="Button" parent="MarginContainer/VBoxContainer/StatusBar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "End Turn"
+disabled = true
+
+[node name="BattleTabContainer" type="TabContainer" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="YourFleet" type="ScrollContainer" parent="MarginContainer/VBoxContainer/BattleTabContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="PlayerGrid" parent="MarginContainer/VBoxContainer/BattleTabContainer/YourFleet" instance=ExtResource("2_gridui")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Enemy" type="ScrollContainer" parent="MarginContainer/VBoxContainer/BattleTabContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="EnemyGrid" parent="MarginContainer/VBoxContainer/BattleTabContainer/Enemy" instance=ExtResource("2_gridui")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ActionPanel" type="PanelContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 130)
+
+[node name="ActionPanelVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ActionPanel"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="ActionHeaderLabel" type="Label" parent="MarginContainer/VBoxContainer/ActionPanel/ActionPanelVBox"]
+layout_mode = 2
+text = "Ship Actions:"
+
+[node name="ShipScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/ActionPanel/ActionPanelVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ShipActionContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ActionPanel/ActionPanelVBox/ShipScrollContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ActionHintLabel" type="Label" parent="MarginContainer/VBoxContainer/ActionPanel/ActionPanelVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Select a ship action, then click the grid to confirm."
+autowrap_mode = 3
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/StatusBar/EndTurnButton" to="." method="_on_end_turn_button_pressed"]
+[connection signal="tab_changed" from="MarginContainer/VBoxContainer/BattleTabContainer" to="." method="_on_tab_changed"]

--- a/src/client/scenes/Lobby.tscn
+++ b/src/client/scenes/Lobby.tscn
@@ -9,35 +9,88 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1_lobby")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -100.0
-offset_top = -75.0
-offset_right = 100.0
-offset_bottom = 75.0
+offset_left = -200.0
+offset_top = -220.0
+offset_right = 200.0
+offset_bottom = 220.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
 
-[node name="TitleLabel" type="Label" parent="VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Lobby"
+theme_override_font_sizes/font_size = 22
 
-[node name="StatusLabel" type="Label" parent="VBoxContainer"]
+[node name="PlayerNameInput" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
-text = "Waiting for players..."
+placeholder_text = "Your name"
+max_length = 24
 
-[node name="StartButton" type="Button" parent="VBoxContainer"]
+[node name="SectionSep1" type="HSeparator" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
-text = "Start Game"
 
-[node name="BackButton" type="Button" parent="VBoxContainer"]
+[node name="CreateLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Create a new lobby:"
+
+[node name="CreateButton" type="Button" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Create Lobby"
+
+[node name="LobbyCodeLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = ""
+
+[node name="SectionSep2" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="JoinLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Or join an existing lobby:"
+
+[node name="LobbyCodeInput" type="LineEdit" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+placeholder_text = "Lobby code"
+max_length = 8
+
+[node name="JoinButton" type="Button" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Join Lobby"
+
+[node name="SectionSep3" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="StatusLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Connecting…"
+autowrap_mode = 3
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "Back"
 
-[connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/CreateButton" to="." method="_on_create_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/JoinButton" to="." method="_on_join_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/src/client/scripts/Battle.gd
+++ b/src/client/scripts/Battle.gd
@@ -4,11 +4,27 @@ extends Control
 ## Drives the combat phase: sends player actions to the relay server and
 ## applies confirmed updates broadcast by the server.
 ## Issues: #43 Synchronise turn actions over the network,
+##         #47 Render player battlefield state,
 ##         #53 Create end-game results screen.
 ##
-## Expected scene nodes (add in Godot editor):
-##   %StatusLabel      – Label showing turn info / messages
-##   %EndBattleButton  – Button (dev-only) to navigate to EndGame
+## Expected scene nodes:
+##   %TurnLabel            – Label showing current turn number
+##   %StatusLabel          – Label showing turn info / messages
+##   %EndTurnButton        – Button to end the player's turn
+##   %BattleTabContainer   – TabContainer with fleet and enemy tabs
+##   %PlayerGrid           – BattlefieldGridUI for the player's fleet
+##   %EnemyGrid            – BattlefieldGridUI for the enemy fog-of-war
+##   %ShipActionContainer  – HBoxContainer populated with per-ship panels
+##   %ActionHintLabel      – Label guiding the player on next input
+
+## One colour per fleet slot — matched by ship id modulo palette size.
+const SHIP_COLORS: Array[Color] = [
+	Color(0.2, 0.6, 1.0, 0.7),
+	Color(1.0, 0.5, 0.1, 0.7),
+	Color(0.2, 0.8, 0.3, 0.7),
+	Color(0.9, 0.2, 0.2, 0.7),
+	Color(0.7, 0.3, 0.9, 0.7),
+]
 
 # ---------------------------------------------------------------------------
 # State
@@ -109,6 +125,7 @@ func _apply_game_state(state: Dictionary) -> void:
 	_game_state.from_dict(state)
 	_is_my_turn = _game_state.current_turn == _my_player_index
 	_set_status("Your turn." if _is_my_turn else "Opponent's turn.")
+	_refresh_player_grid()
 
 
 func _on_action_received(msg: Dictionary) -> void:
@@ -168,6 +185,25 @@ func _set_status(text: String) -> void:
 		(%StatusLabel as Label).text = text
 
 
-func _on_end_battle_button_pressed() -> void:
-	NetworkManager.last_match_result = {}
-	get_tree().change_scene_to_file("res://src/client/scenes/EndGame.tscn")
+## Redraws the player's fleet grid from the current game state.
+## Shows each ship in its assigned colour; hits from enemy missiles are marked.
+func _refresh_player_grid() -> void:
+	if not has_node("%PlayerGrid"):
+		return
+	var grid_ui := %PlayerGrid as Control
+	var ship_cells: Dictionary = {}
+	for ship in _game_state.ships:
+		var color: Color = (
+			Color(0.35, 0.35, 0.35, 0.7)
+			if ship.get("is_destroyed", false)
+			else SHIP_COLORS[ship["id"] % SHIP_COLORS.size()]
+		)
+		for i in range(ship.get("length", 0)):
+			var cell: Vector2i = ship["position"] + ship["facing"] * i
+			ship_cells[cell] = color
+	grid_ui.set_placed_ship_cells(ship_cells)
+	var state_cells: Dictionary = {}
+	for missile in _game_state.missile_history:
+		if missile.get("player", -1) != _my_player_index:
+			state_cells[missile["position"]] = missile["result"]
+	grid_ui.set_state_cells(state_cells)

--- a/src/client/scripts/Battle.gd
+++ b/src/client/scripts/Battle.gd
@@ -4,11 +4,18 @@ extends Control
 ## Drives the combat phase: sends player actions to the relay server and
 ## applies confirmed updates broadcast by the server.
 ## Issues: #43 Synchronise turn actions over the network,
+##         #46 Build tabbed battlefield interface,
 ##         #53 Create end-game results screen.
 ##
-## Expected scene nodes (add in Godot editor):
-##   %StatusLabel      – Label showing turn info / messages
-##   %EndBattleButton  – Button (dev-only) to navigate to EndGame
+## Expected scene nodes:
+##   %TurnLabel            – Label showing current turn number
+##   %StatusLabel          – Label showing turn info / messages
+##   %EndTurnButton        – Button to end the player's turn
+##   %BattleTabContainer   – TabContainer with fleet and enemy tabs
+##   %PlayerGrid           – BattlefieldGridUI for the player's fleet
+##   %EnemyGrid            – BattlefieldGridUI for the enemy fog-of-war
+##   %ShipActionContainer  – HBoxContainer populated with per-ship panels
+##   %ActionHintLabel      – Label guiding the player on next input
 
 # ---------------------------------------------------------------------------
 # State
@@ -168,6 +175,13 @@ func _set_status(text: String) -> void:
 		(%StatusLabel as Label).text = text
 
 
-func _on_end_battle_button_pressed() -> void:
-	NetworkManager.last_match_result = {}
-	get_tree().change_scene_to_file("res://src/client/scenes/EndGame.tscn")
+## Triggered by the End Turn button in the status bar.
+func _on_end_turn_button_pressed() -> void:
+	submit_end_turn()
+	if has_node("%EndTurnButton"):
+		(%EndTurnButton as Button).disabled = true
+
+
+## Called when the player switches between the fleet and enemy tabs.
+func _on_tab_changed(_tab_index: int) -> void:
+	pass

--- a/src/client/scripts/Battle.gd
+++ b/src/client/scripts/Battle.gd
@@ -4,11 +4,13 @@ extends Control
 ## Drives the combat phase: sends player actions to the relay server and
 ## applies confirmed updates broadcast by the server.
 ## Issues: #43 Synchronise turn actions over the network,
+##         #50 Add turn and status indicators,
 ##         #53 Create end-game results screen.
 ##
 ## Expected scene nodes (add in Godot editor):
+##   %TurnLabel        – Label showing whose turn it is
 ##   %StatusLabel      – Label showing turn info / messages
-##   %EndBattleButton  – Button (dev-only) to navigate to EndGame
+##   %EndTurnButton    – Button to end the player's turn (enabled only on player's turn)
 
 # ---------------------------------------------------------------------------
 # State
@@ -109,6 +111,8 @@ func _apply_game_state(state: Dictionary) -> void:
 	_game_state.from_dict(state)
 	_is_my_turn = _game_state.current_turn == _my_player_index
 	_set_status("Your turn." if _is_my_turn else "Opponent's turn.")
+	if has_node("%EndTurnButton"):
+		(%EndTurnButton as Button).disabled = not _is_my_turn
 
 
 func _on_action_received(msg: Dictionary) -> void:
@@ -139,6 +143,8 @@ func _apply_opponent_action(action: String, ship_id: int, params: Dictionary) ->
 func _on_turn_ended(_msg: Dictionary) -> void:
 	_is_my_turn = true
 	_set_status("Your turn.")
+	if has_node("%EndTurnButton"):
+		(%EndTurnButton as Button).disabled = false
 
 
 func _on_opponent_disconnected() -> void:
@@ -166,6 +172,8 @@ func _on_game_over(msg: Dictionary) -> void:
 func _set_status(text: String) -> void:
 	if has_node("%StatusLabel"):
 		(%StatusLabel as Label).text = text
+	if has_node("%TurnLabel"):
+		(%TurnLabel as Label).text = "Your turn" if _is_my_turn else "Opp's turn"
 
 
 func _on_end_battle_button_pressed() -> void:

--- a/src/client/scripts/Battle.gd
+++ b/src/client/scripts/Battle.gd
@@ -4,11 +4,16 @@ extends Control
 ## Drives the combat phase: sends player actions to the relay server and
 ## applies confirmed updates broadcast by the server.
 ## Issues: #43 Synchronise turn actions over the network,
+##         #49 Add ship action selection panel,
 ##         #53 Create end-game results screen.
 ##
-## Expected scene nodes (add in Godot editor):
-##   %StatusLabel      – Label showing turn info / messages
-##   %EndBattleButton  – Button (dev-only) to navigate to EndGame
+## Expected scene nodes:
+##   %StatusLabel          – Label showing turn info / messages
+##   %EndTurnButton        – Button to end the player's turn
+##   %BattleTabContainer   – TabContainer (index 1 = Enemy tab)
+##   %EnemyGrid            – BattlefieldGridUI for enemy fog-of-war
+##   %ShipActionContainer  – HBoxContainer populated with per-ship panels
+##   %ActionHintLabel      – Label guiding the player on next input
 
 # ---------------------------------------------------------------------------
 # State
@@ -17,6 +22,7 @@ extends Control
 var _my_player_index := 0
 var _game_state: GameState = GameState.new()
 var _is_my_turn := false
+var _pending_action: Dictionary = {}  # {ship_id, action} while awaiting grid click
 
 # ---------------------------------------------------------------------------
 # Lifecycle
@@ -26,6 +32,18 @@ var _is_my_turn := false
 func _ready() -> void:
 	NetworkManager.message_received.connect(_on_message_received)
 	NetworkManager.disconnected_from_server.connect(_on_disconnected)
+	if has_node("%EnemyGrid"):
+		var eg := %EnemyGrid as Control
+		eg.cell_selected.connect(_on_enemy_grid_cell_selected)
+		eg.cell_hovered.connect(
+			func(pos: Vector2i) -> void:
+				if _pending_action.is_empty():
+					return
+				var cells: Array[Vector2i] = (
+					ProbeRules.get_probe_cells(pos) if _pending_action.get("action") == "probe" else [pos]
+				)
+				eg.set_action_preview(cells)
+		)
 
 
 func _exit_tree() -> void:
@@ -36,36 +54,8 @@ func _exit_tree() -> void:
 
 
 # ---------------------------------------------------------------------------
-# Public API – called by UI action controls
+# Action submission
 # ---------------------------------------------------------------------------
-
-
-## Sends a move_forward action for the given ship.
-func submit_move_forward(ship_id: int, steps: int) -> void:
-	if not _is_my_turn:
-		return
-	NetworkManager.send_perform_action(ship_id, "move_forward", {"steps": steps})
-
-
-## Sends a turn action for the given ship.
-func submit_turn(ship_id: int, direction: String) -> void:
-	if not _is_my_turn:
-		return
-	NetworkManager.send_perform_action(ship_id, "turn", {"direction": direction})
-
-
-## Sends a probe action for the given ship.
-func submit_probe(ship_id: int, center_x: int, center_y: int) -> void:
-	if not _is_my_turn:
-		return
-	NetworkManager.send_perform_action(ship_id, "probe", {"x": center_x, "y": center_y})
-
-
-## Sends a missile action for the given ship.
-func submit_missile(ship_id: int, target_x: int, target_y: int) -> void:
-	if not _is_my_turn:
-		return
-	NetworkManager.send_perform_action(ship_id, "missile", {"x": target_x, "y": target_y})
 
 
 ## Ends the current player's turn and sends the latest state snapshot.
@@ -73,8 +63,16 @@ func submit_end_turn() -> void:
 	if not _is_my_turn:
 		return
 	_is_my_turn = false
+	_pending_action = {}
 	NetworkManager.send_end_turn(_game_state.to_dict())
 	_set_status("Waiting for opponent…")
+
+
+## Sends a validated action to the server. Only called when it is the player's turn.
+func _send_ship_action(ship_id: int, action: String, params: Dictionary) -> void:
+	if not _is_my_turn:
+		return
+	NetworkManager.send_perform_action(ship_id, action, params)
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +107,7 @@ func _apply_game_state(state: Dictionary) -> void:
 	_game_state.from_dict(state)
 	_is_my_turn = _game_state.current_turn == _my_player_index
 	_set_status("Your turn." if _is_my_turn else "Opponent's turn.")
+	_build_action_panel()
 
 
 func _on_action_received(msg: Dictionary) -> void:
@@ -138,7 +137,9 @@ func _apply_opponent_action(action: String, ship_id: int, params: Dictionary) ->
 
 func _on_turn_ended(_msg: Dictionary) -> void:
 	_is_my_turn = true
+	_pending_action = {}
 	_set_status("Your turn.")
+	_build_action_panel()
 
 
 func _on_opponent_disconnected() -> void:
@@ -159,6 +160,78 @@ func _on_game_over(msg: Dictionary) -> void:
 
 
 # ---------------------------------------------------------------------------
+# Action panel
+# ---------------------------------------------------------------------------
+
+
+## Rebuilds the ship action panel for the current turn. Clears all buttons when
+## it is not the player's turn so the panel does not show stale controls.
+func _build_action_panel() -> void:
+	if not has_node("%ShipActionContainer"):
+		return
+	var container := %ShipActionContainer as HBoxContainer
+	for child in container.get_children():
+		child.queue_free()
+	if not _is_my_turn:
+		return
+	for ship in _game_state.ships:
+		if ship.get("is_destroyed", false):
+			continue
+		var sid: int = ship["id"]
+		var stype: String = ship.get("type", "")
+		var card := VBoxContainer.new()
+		var name_lbl := Label.new()
+		name_lbl.text = "%s (HP:%d)" % [stype.capitalize(), ship.get("health", 0)]
+		card.add_child(name_lbl)
+		for pair in [
+			["Fwd", "move_forward"],
+			["Left", "turn_left"],
+			["Right", "turn_right"],
+			["Probe", "probe"],
+			["Missile", "missile"]
+		]:
+			var btn := Button.new()
+			btn.text = pair[0]
+			btn.pressed.connect(_on_ship_action_selected.bind(sid, pair[1]))
+			card.add_child(btn)
+		container.add_child(card)
+
+
+## Handles a ship action button press. Immediate actions are sent straight to
+## the server; targeting actions (probe, missile) wait for a grid click.
+func _on_ship_action_selected(ship_id: int, action: String) -> void:
+	if not _is_my_turn:
+		return
+	if action in ["probe", "missile"]:
+		_pending_action = {"ship_id": ship_id, "action": action}
+		if has_node("%BattleTabContainer"):
+			(%BattleTabContainer as TabContainer).current_tab = 1
+		if has_node("%ActionHintLabel"):
+			(%ActionHintLabel as Label).text = "Click the enemy grid to target your %s." % action
+		return
+	_pending_action = {}
+	if action == "move_forward":
+		_send_ship_action(ship_id, "move_forward", {"steps": 1})
+	elif action in ["turn_left", "turn_right"]:
+		var dir := "left" if action == "turn_left" else "right"
+		_send_ship_action(ship_id, "turn", {"direction": dir})
+
+
+## Called when the player clicks the enemy grid. Confirms a pending targeting action.
+func _on_enemy_grid_cell_selected(pos: Vector2i) -> void:
+	if _pending_action.is_empty():
+		return
+	var ship_id: int = _pending_action.get("ship_id", -1)
+	var action: String = _pending_action.get("action", "")
+	_pending_action = {}
+	_send_ship_action(ship_id, action, {"x": pos.x, "y": pos.y})
+	if has_node("%EnemyGrid"):
+		(%EnemyGrid as Control).set_action_preview([])
+	if has_node("%ActionHintLabel"):
+		(%ActionHintLabel as Label).text = "Action sent."
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -166,8 +239,3 @@ func _on_game_over(msg: Dictionary) -> void:
 func _set_status(text: String) -> void:
 	if has_node("%StatusLabel"):
 		(%StatusLabel as Label).text = text
-
-
-func _on_end_battle_button_pressed() -> void:
-	NetworkManager.last_match_result = {}
-	get_tree().change_scene_to_file("res://src/client/scenes/EndGame.tscn")

--- a/src/client/scripts/Battle.gd
+++ b/src/client/scripts/Battle.gd
@@ -109,6 +109,7 @@ func _apply_game_state(state: Dictionary) -> void:
 	_game_state.from_dict(state)
 	_is_my_turn = _game_state.current_turn == _my_player_index
 	_set_status("Your turn." if _is_my_turn else "Opponent's turn.")
+	_refresh_enemy_grid()
 
 
 func _on_action_received(msg: Dictionary) -> void:
@@ -171,3 +172,21 @@ func _set_status(text: String) -> void:
 func _on_end_battle_button_pressed() -> void:
 	NetworkManager.last_match_result = {}
 	get_tree().change_scene_to_file("res://src/client/scenes/EndGame.tscn")
+
+
+## Redraws the enemy fog-of-war grid from missile and probe history.
+## Only cells hit, missed, or revealed by the local player's actions are shown.
+func _refresh_enemy_grid() -> void:
+	if not has_node("%EnemyGrid"):
+		return
+	var grid_ui := %EnemyGrid as Control
+	var state_cells: Dictionary = {}
+	for missile in _game_state.missile_history:
+		if missile.get("player", -1) == _my_player_index:
+			state_cells[missile["position"]] = missile["result"]
+	for probe in _game_state.probe_history:
+		if probe.get("player", -1) == _my_player_index:
+			for pos in probe.get("result", []):
+				if pos not in state_cells:
+					state_cells[pos] = "revealed"
+	grid_ui.set_state_cells(state_cells)

--- a/src/client/scripts/BattlefieldGridUI.gd
+++ b/src/client/scripts/BattlefieldGridUI.gd
@@ -2,7 +2,8 @@ extends Control
 
 ## BattlefieldGridUI
 ## Renders the 120x12 grid and handles screen-to-grid translation.
-## Supports overlay rendering for placed ships and placement previews.
+## Supports overlay rendering for placed ships, placement previews,
+## cell state markers (hit/miss/revealed), and action targeting previews.
 
 signal cell_selected(grid_pos: Vector2i)
 signal cell_hovered(grid_pos: Vector2i)
@@ -27,6 +28,8 @@ var _hover_cell: Vector2i = Vector2i(-1, -1)
 var _placed_ship_cells: Dictionary = {}  # Vector2i -> Color
 var _preview_cells: Array[Vector2i] = []
 var _preview_valid: bool = true
+var _action_preview_cells: Array[Vector2i] = []
+var _action_preview_color: Color = Color(1.0, 0.85, 0.0, 0.5)
 
 
 func _ready() -> void:
@@ -67,6 +70,10 @@ func _draw() -> void:
 	if selected_cell != Vector2i(-1, -1):
 		var rect = Rect2(grid_to_screen(selected_cell), Vector2(CELL_SIZE, CELL_SIZE))
 		draw_rect(rect, selection_color)
+
+	# Draw action preview cells (targeting highlight for probe/missile actions)
+	for cell in _action_preview_cells:
+		draw_rect(Rect2(grid_to_screen(cell), Vector2(CELL_SIZE, CELL_SIZE)), _action_preview_color)
 
 	# Draw vertical lines
 	for x in range(GRID_WIDTH + 1):
@@ -124,4 +131,12 @@ func set_placed_ship_cells(cells: Dictionary) -> void:
 func set_preview_cells(cells: Array[Vector2i], valid: bool = true) -> void:
 	_preview_cells = cells
 	_preview_valid = valid
+	queue_redraw()
+
+
+## Sets the action preview overlay for combat targeting (probe/missile).
+## Pass an empty array to clear the preview. The optional color overrides the default yellow tint.
+func set_action_preview(cells: Array[Vector2i], color: Color = Color(1.0, 0.85, 0.0, 0.5)) -> void:
+	_action_preview_cells = cells
+	_action_preview_color = color
 	queue_redraw()

--- a/src/client/scripts/BattlefieldGridUI.gd
+++ b/src/client/scripts/BattlefieldGridUI.gd
@@ -25,6 +25,7 @@ const CELL_SIZE = 16
 var selected_cell: Vector2i = Vector2i(-1, -1)
 var _hover_cell: Vector2i = Vector2i(-1, -1)
 var _placed_ship_cells: Dictionary = {}  # Vector2i -> Color
+var _state_cells: Dictionary = {}  # Vector2i -> String ("hit" | "miss" | "revealed")
 var _preview_cells: Array[Vector2i] = []
 var _preview_valid: bool = true
 
@@ -57,6 +58,23 @@ func _draw() -> void:
 	for cell: Vector2i in _placed_ship_cells:
 		var color: Color = _placed_ship_cells[cell]
 		draw_rect(Rect2(grid_to_screen(cell), Vector2(CELL_SIZE, CELL_SIZE)), color)
+
+	# Draw cell state markers: hit (red X), miss (grey circle), revealed (orange border)
+	for cell: Vector2i in _state_cells:
+		var cell_rect := Rect2(grid_to_screen(cell), Vector2(CELL_SIZE, CELL_SIZE))
+		match _state_cells[cell]:
+			"hit":
+				draw_line(cell_rect.position, cell_rect.end, Color(0.9, 0.1, 0.1, 0.9), 2.0)
+				draw_line(
+					cell_rect.position + Vector2(CELL_SIZE, 0),
+					cell_rect.position + Vector2(0, CELL_SIZE),
+					Color(0.9, 0.1, 0.1, 0.9),
+					2.0
+				)
+			"miss":
+				draw_circle(cell_rect.get_center(), CELL_SIZE * 0.25, Color(0.7, 0.7, 0.7, 0.8))
+			"revealed":
+				draw_rect(cell_rect, Color(1.0, 0.6, 0.0, 0.35))
 
 	# Draw preview cells
 	var p_color := preview_valid_color if _preview_valid else preview_invalid_color
@@ -117,6 +135,13 @@ func get_cell_center(grid_pos: Vector2i) -> Vector2:
 ## Sets the overlay cells for placed ships. Keys are Vector2i positions, values are Colors.
 func set_placed_ship_cells(cells: Dictionary) -> void:
 	_placed_ship_cells = cells
+	queue_redraw()
+
+
+## Sets the cell state overlay for combat view. Keys are Vector2i positions;
+## values are "hit", "miss", or "revealed".
+func set_state_cells(states: Dictionary) -> void:
+	_state_cells = states
 	queue_redraw()
 
 

--- a/src/shared/FogOfWarState.gd
+++ b/src/shared/FogOfWarState.gd
@@ -1,0 +1,63 @@
+class_name FogOfWarState
+extends RefCounted
+
+## FogOfWarState
+## Tracks what a player can see on the opponent's grid.
+## Cells are recorded when revealed by probes or resolved by missiles.
+## Issue: #74 Implement fog-of-war data model.
+
+const CELL_REVEALED = "revealed"
+const CELL_HIT = "hit"
+const CELL_MISS = "miss"
+
+var _visible_cells: Dictionary = {}  # Vector2i -> String (state constant)
+
+
+## Marks cells as revealed from a successful probe. Already-recorded hit/miss cells
+## are not overwritten so that combat results take priority.
+func apply_probe_result(positions: Array) -> void:
+	for pos in positions:
+		if pos not in _visible_cells:
+			_visible_cells[pos] = CELL_REVEALED
+
+
+## Records a missile result at the given position using MissileRules result constants.
+func apply_missile_result(pos: Vector2i, result: String) -> void:
+	if result == MissileRules.RESULT_HIT:
+		_visible_cells[pos] = CELL_HIT
+	elif result == MissileRules.RESULT_MISS:
+		_visible_cells[pos] = CELL_MISS
+
+
+## Returns true if the cell has been observed (revealed, hit, or missed).
+func is_cell_observed(pos: Vector2i) -> bool:
+	return pos in _visible_cells
+
+
+## Returns the observed state string for a cell, or an empty string if not observed.
+func get_cell_state(pos: Vector2i) -> String:
+	return _visible_cells.get(pos, "")
+
+
+## Returns a copy of all observed cells mapped to their state strings.
+func get_visible_cells() -> Dictionary:
+	return _visible_cells.duplicate()
+
+
+## Serialises the fog state to a dictionary for network transport.
+## Keys are "x,y" strings; values are state strings.
+func to_dict() -> Dictionary:
+	var result: Dictionary = {}
+	for pos: Vector2i in _visible_cells:
+		result["%d,%d" % [pos.x, pos.y]] = _visible_cells[pos]
+	return result
+
+
+## Deserialises the fog state from a dictionary produced by to_dict().
+func from_dict(data: Dictionary) -> void:
+	_visible_cells.clear()
+	for key: String in data:
+		var parts: PackedStringArray = key.split(",")
+		if parts.size() == 2:
+			var pos := Vector2i(int(parts[0]), int(parts[1]))
+			_visible_cells[pos] = data[key]

--- a/src/shared/GameEventLog.gd
+++ b/src/shared/GameEventLog.gd
@@ -1,0 +1,77 @@
+class_name GameEventLog
+extends RefCounted
+
+## GameEventLog
+## Records structured game events with type, player, turn, and optional data.
+## Provides queries by turn or player and supports serialisation for network transport.
+## Issue: #73 Add structured game event logging.
+
+const EVENT_MOVE = "move"
+const EVENT_TURN_SHIP = "turn_ship"
+const EVENT_PROBE = "probe"
+const EVENT_MISSILE = "missile"
+const EVENT_PROBE_MASK = "probe_mask"
+const EVENT_END_TURN = "end_turn"
+const EVENT_GAME_OVER = "game_over"
+
+var _events: Array = []
+
+
+## Appends a new event. data is an optional dictionary of event-specific fields.
+func log_event(event_type: String, player_index: int, turn_number: int, data: Dictionary = {}) -> void:
+	(
+		_events
+		. append(
+			{
+				"type": event_type,
+				"player_index": player_index,
+				"turn": turn_number,
+				"data": data.duplicate(),
+			}
+		)
+	)
+
+
+## Returns a shallow copy of all recorded events.
+func get_events() -> Array:
+	return _events.duplicate()
+
+
+## Returns events recorded for a specific turn number.
+func get_events_for_turn(turn_number: int) -> Array:
+	var result: Array = []
+	for event in _events:
+		if event.get("turn", -1) == turn_number:
+			result.append(event.duplicate())
+	return result
+
+
+## Returns events recorded for a specific player index.
+func get_events_for_player(player_index: int) -> Array:
+	var result: Array = []
+	for event in _events:
+		if event.get("player_index", -1) == player_index:
+			result.append(event.duplicate())
+	return result
+
+
+## Returns the most recent event, or an empty dictionary if the log is empty.
+func get_last_event() -> Dictionary:
+	if _events.is_empty():
+		return {}
+	return _events.back().duplicate()
+
+
+## Returns the total number of recorded events.
+func event_count() -> int:
+	return _events.size()
+
+
+## Serialises the log to an array for network transport.
+func to_dict() -> Array:
+	return _events.duplicate(true)
+
+
+## Restores the log from an array produced by to_dict().
+func from_dict(data: Array) -> void:
+	_events = data.duplicate(true)

--- a/tests/unit/test_fog_of_war.gd
+++ b/tests/unit/test_fog_of_war.gd
@@ -1,0 +1,66 @@
+extends "res://addons/gut/test.gd"
+
+const FogOfWarState = preload("res://src/shared/FogOfWarState.gd")
+const MissileRules = preload("res://src/shared/MissileRules.gd")
+
+
+func test_initial_state_empty():
+	var fog = FogOfWarState.new()
+	assert_eq(fog.get_visible_cells().size(), 0, "No cells visible initially")
+
+
+func test_apply_probe_result_marks_revealed():
+	var fog = FogOfWarState.new()
+	var positions = [Vector2i(5, 3), Vector2i(6, 3)]
+	fog.apply_probe_result(positions)
+	assert_true(fog.is_cell_observed(Vector2i(5, 3)), "Cell should be observed after probe")
+	assert_eq(fog.get_cell_state(Vector2i(5, 3)), FogOfWarState.CELL_REVEALED)
+
+
+func test_apply_probe_does_not_overwrite_hit():
+	var fog = FogOfWarState.new()
+	fog.apply_missile_result(Vector2i(5, 3), MissileRules.RESULT_HIT)
+	fog.apply_probe_result([Vector2i(5, 3)])
+	assert_eq(fog.get_cell_state(Vector2i(5, 3)), FogOfWarState.CELL_HIT, "Hit should not be overwritten by probe")
+
+
+func test_apply_missile_hit():
+	var fog = FogOfWarState.new()
+	fog.apply_missile_result(Vector2i(10, 5), MissileRules.RESULT_HIT)
+	assert_eq(fog.get_cell_state(Vector2i(10, 5)), FogOfWarState.CELL_HIT)
+
+
+func test_apply_missile_miss():
+	var fog = FogOfWarState.new()
+	fog.apply_missile_result(Vector2i(20, 8), MissileRules.RESULT_MISS)
+	assert_eq(fog.get_cell_state(Vector2i(20, 8)), FogOfWarState.CELL_MISS)
+
+
+func test_unobserved_cell_returns_empty():
+	var fog = FogOfWarState.new()
+	assert_false(fog.is_cell_observed(Vector2i(0, 0)))
+	assert_eq(fog.get_cell_state(Vector2i(0, 0)), "")
+
+
+func test_serialization_roundtrip():
+	var fog = FogOfWarState.new()
+	fog.apply_probe_result([Vector2i(3, 2)])
+	fog.apply_missile_result(Vector2i(7, 4), MissileRules.RESULT_HIT)
+	fog.apply_missile_result(Vector2i(15, 1), MissileRules.RESULT_MISS)
+
+	var data = fog.to_dict()
+	var fog2 = FogOfWarState.new()
+	fog2.from_dict(data)
+
+	assert_eq(fog2.get_cell_state(Vector2i(3, 2)), FogOfWarState.CELL_REVEALED)
+	assert_eq(fog2.get_cell_state(Vector2i(7, 4)), FogOfWarState.CELL_HIT)
+	assert_eq(fog2.get_cell_state(Vector2i(15, 1)), FogOfWarState.CELL_MISS)
+	assert_false(fog2.is_cell_observed(Vector2i(0, 0)))
+
+
+func test_get_visible_cells_returns_copy():
+	var fog = FogOfWarState.new()
+	fog.apply_probe_result([Vector2i(1, 1)])
+	var cells = fog.get_visible_cells()
+	cells[Vector2i(99, 99)] = "revealed"
+	assert_false(fog.is_cell_observed(Vector2i(99, 99)), "Modifying copy should not affect internal state")

--- a/tests/unit/test_game_event_log.gd
+++ b/tests/unit/test_game_event_log.gd
@@ -1,0 +1,72 @@
+extends "res://addons/gut/test.gd"
+
+const GameEventLog = preload("res://src/shared/GameEventLog.gd")
+
+
+func test_initial_log_empty():
+	var log = GameEventLog.new()
+	assert_eq(log.event_count(), 0)
+	assert_true(log.get_events().is_empty())
+	assert_true(log.get_last_event().is_empty())
+
+
+func test_log_single_event():
+	var log = GameEventLog.new()
+	log.log_event(GameEventLog.EVENT_MOVE, 0, 1, {"ship_id": 2, "steps": 1})
+	assert_eq(log.event_count(), 1)
+	var event = log.get_last_event()
+	assert_eq(event["type"], GameEventLog.EVENT_MOVE)
+	assert_eq(event["player_index"], 0)
+	assert_eq(event["turn"], 1)
+	assert_eq(event["data"]["ship_id"], 2)
+
+
+func test_log_multiple_events():
+	var log = GameEventLog.new()
+	log.log_event(GameEventLog.EVENT_PROBE, 0, 1)
+	log.log_event(GameEventLog.EVENT_MISSILE, 0, 1)
+	log.log_event(GameEventLog.EVENT_END_TURN, 0, 1)
+	assert_eq(log.event_count(), 3)
+
+
+func test_get_events_for_turn():
+	var log = GameEventLog.new()
+	log.log_event(GameEventLog.EVENT_MOVE, 0, 1)
+	log.log_event(GameEventLog.EVENT_PROBE, 1, 2)
+	log.log_event(GameEventLog.EVENT_MISSILE, 0, 3)
+	var turn2 = log.get_events_for_turn(2)
+	assert_eq(turn2.size(), 1)
+	assert_eq(turn2[0]["type"], GameEventLog.EVENT_PROBE)
+
+
+func test_get_events_for_player():
+	var log = GameEventLog.new()
+	log.log_event(GameEventLog.EVENT_MOVE, 0, 1)
+	log.log_event(GameEventLog.EVENT_PROBE, 1, 1)
+	log.log_event(GameEventLog.EVENT_MISSILE, 0, 1)
+	var p0 = log.get_events_for_player(0)
+	assert_eq(p0.size(), 2)
+	var p1 = log.get_events_for_player(1)
+	assert_eq(p1.size(), 1)
+
+
+func test_get_last_event_no_mutation():
+	var log = GameEventLog.new()
+	log.log_event(GameEventLog.EVENT_GAME_OVER, 0, 5, {"winner": 0})
+	var event = log.get_last_event()
+	event["type"] = "tampered"
+	assert_eq(log.get_last_event()["type"], GameEventLog.EVENT_GAME_OVER, "Mutating returned copy must not affect log")
+
+
+func test_serialization_roundtrip():
+	var log = GameEventLog.new()
+	log.log_event(GameEventLog.EVENT_PROBE, 0, 1, {"x": 10, "y": 5})
+	log.log_event(GameEventLog.EVENT_MISSILE, 1, 2, {"x": 20, "y": 3})
+
+	var data = log.to_dict()
+	var log2 = GameEventLog.new()
+	log2.from_dict(data)
+
+	assert_eq(log2.event_count(), 2)
+	assert_eq(log2.get_events_for_turn(1)[0]["data"]["x"], 10)
+	assert_eq(log2.get_events_for_player(1)[0]["type"], GameEventLog.EVENT_MISSILE)


### PR DESCRIPTION
## Summary

- **#46** Build tabbed battlefield interface (player fleet + enemy fog-of-war tabs)
- **#47** Render player battlefield state (ships in palette colours, enemy hit/miss markers)
- **#48** Render enemy fog-of-war battlefield (own missile/probe results on enemy grid)
- **#49** Add ship action selection panel (per-ship action cards with Fwd/Turn/Probe/Missile)
- **#50** Add turn and status indicators (TurnLabel, StatusLabel, EndTurnButton enable/disable)
- **#70** Implement lobby waiting screen (full Lobby.tscn with name/code inputs, create/join/back)
- **#73** Add structured game event logging (GameEventLog shared model with serialisation)
- **#74** Implement fog-of-war data model (FogOfWarState shared model with serialisation)
- **#77** Implement action preview system (hover overlay on enemy grid for probe/missile targeting)

## Test plan

- [ ] Run GUT unit tests: `godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests/unit -ginclude_subdirs -glog=1 -gexit`
- [ ] Verify `gdlint .` and `gdformat --check .` pass with no errors
- [ ] Confirm `test_fog_of_war.gd` and `test_game_event_log.gd` all pass
- [ ] Launch game and navigate Lobby → ShipPlacement → Battle; verify tab switching, action panel, and grid overlays render correctly
- [ ] Verify EndTurnButton is disabled on opponent's turn and re-enabled on player's turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)